### PR TITLE
Add railway class=transit

### DIFF
--- a/style.json
+++ b/style.json
@@ -258,6 +258,55 @@
       }
     },
     {
+      "id": "tunnel_railway_transit",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 0,
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "transit"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
+      "paint": {
+        "line-color": "hsl(34, 12%, 66%)",
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              0
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        },
+        "line-dasharray": [
+          3,
+          3
+        ]
+      }
+    },
+    {
       "id": "building",
       "type": "fill",
       "source": "openmaptiles",
@@ -749,6 +798,44 @@
           ]
         },
         "line-offset": 0
+      }
+    },
+    {
+      "id": "railway-transit",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "transit"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(34, 12%, 66%)",
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              0
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        }
       }
     },
     {


### PR DESCRIPTION
Update style according to 
https://github.com/openmaptiles/openmaptiles/issues/300

Also added the underground rails (brunnel=tunnel) of class=transit and positioned them below the building layer. 

Do you want to include these underground rails in the style?

Currently there are some entrances to underground stations which are looking a bit weird without rails, like in the example below:

![image](https://user-images.githubusercontent.com/20856381/28078742-21675774-6666-11e7-913d-b8fee7a685c5.png)

Same area with underground rails:

![image](https://user-images.githubusercontent.com/20856381/28078799-564f4172-6666-11e7-803e-01c711707a6e.png)






